### PR TITLE
change function focuswin and bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ keyboard shortcuts (don't forget to copy those to `config.h`):
 +	{ MODKEY|ShiftMask,             XK_o,      restorewin,     {0} },
 +   { MODKEY,                       XK_w,      hideotherwins,  {0}},
 +   { MODKEY|ShiftMask,             XK_w,      restoreotherwins, {0}},
-+   { MODKEY|ShiftMask,             XK_u,      focuswin,       {.i = +1}},
-+   { MODKEY|ShiftMask,             XK_l,      focuswin,       {.i = -1}},
 ```
 
 ### Usage
@@ -27,8 +25,7 @@ By default, after applying the patch, `MOD` + `o` is the shortcut to hide
 restore the most recent hidden window in the current tag.
 Use `MOD` + 'w', you will hide others windows in this tag, which is just like fullscreen but isn't. 
 Use `MOD` + 'Shift' + 'w', you can restore all windows which is hidden in this tag.
-Use `MOD` + 'Shift' + 'u'/'l'(you'd better use this shortcut after `MOD` + 'w'), you can change the 
-window to display, which is just like `focusstack`.(In fact, the shortcut of my focusstack is `Mod` + `u`/`l`).
+Use the shortcut of focusstack, you can change the window to display if other windows are all hidden.
 
 ### Author
 [@theniceboy](https://github.com/theniceboy)

--- a/dwm-hide-and-restore.diff
+++ b/dwm-hide-and-restore.diff
@@ -1,77 +1,103 @@
 diff --git a/config.def.h b/config.def.h
-index 69a2430..e3c6118 100644
+index 1c0b587..b4cb248 100644
 --- a/config.def.h
 +++ b/config.def.h
-@@ -103,6 +103,8 @@ static Key keys[] = {
- 	{ MODKEY|ShiftMask,             XK_l,      incnmaster,     {.i = -1 } },
+@@ -70,6 +70,10 @@ static Key keys[] = {
  	{ MODKEY,                       XK_h,      setmfact,       {.f = -0.05} },
  	{ MODKEY,                       XK_l,      setmfact,       {.f = +0.05} },
-+	{ MODKEY,                       XK_o,      hidewin,        {0} },
-+	{ MODKEY|ShiftMask,             XK_o,      restorewin,     {0} },
-+   { MODKEY,                       XK_w,      hideotherwins,  {0}},
-+   { MODKEY|ShiftMask,             XK_w,      restoreotherwins, {0}},
-+   { MODKEY|ShiftMask,             XK_u,      focuswin,       {.i = +1}},
-+   { MODKEY|ShiftMask,             XK_l,      focuswin,       {.i = -1}},
- 	{ MODKEY|ShiftMask,             XK_Return, zoom,           {0} },
- 	{ MODKEY,                       XK_Tab,    view,           {0} },
- 	{ MODKEY|ShiftMask,             XK_q,      killclient,     {0} },
++	{MODKEY,						XK_o, 	   hidewin, 	   {0}},
++   {MODKEY|ShiftMask, 			    XK_o, 	   restorewin, 	   {0}},
++   {MODKEY, 						XK_w, 	   hideotherwins,  {0}},
++   {MODKEY|ShiftMask, 				XK_w, 	   restoreotherwins, {0}},
+	{ MODKEY,                       XK_Return, zoom,           {0} },
+	{ MODKEY,                       XK_Tab,    view,           {0} },
+	{ MODKEY|ShiftMask,             XK_q,      killclient,     {0} },
 diff --git a/dwm.c b/dwm.c
-index 770a4bc..8dc728e 100644
+index 4465af1..8046d56 100644
 --- a/dwm.c
 +++ b/dwm.c
-@@ -232,6 +232,8 @@ static void togglefloating(const Arg *arg);
+@@ -213,6 +213,12 @@ static void togglebar(const Arg *arg);
+ static void togglefloating(const Arg *arg);
  static void toggletag(const Arg *arg);
  static void toggleview(const Arg *arg);
- static void togglewin(const Arg *arg);
 +static void hidewin(const Arg *arg);
 +static void restorewin(const Arg *arg);
 +static void hideotherwins(const Arg *arg);
 +static void restoreotherwins(const Arg *arg);
++static int issinglewin(const Arg *arg);
 +static void focuswin(const Arg *arg);
  static void unfocus(Client *c, int setfocus);
  static void unmanage(Client *c, int destroyed);
  static void unmapnotify(XEvent *e);
-@@ -294,6 +296,10 @@ static Visual *visual;
- static int depth;
- static Colormap cmap;
+@@ -268,6 +274,10 @@ static Drw *drw;
+ static Monitor *mons, *selmon;
+ static Window root, wmcheckwin;
  
 +#define hiddenWinStackMax 100
 +static int hiddenWinStackTop = -1;
-+static Client* hiddenWinStack[hiddenWinStackMax];
++static Client *hiddenWinStack[hiddenWinStackMax];
 +
  /* configuration, allows nested code to access above variables */
  #include "config.h"
+@@ -834,19 +834,24 @@ focusstack(const Arg *arg)
+ {
+ 	Client *c = NULL, *i;
  
-@@ -1993,6 +1999,31 @@ toggleview(const Arg *arg)
++    if (issinglewin(arg)) {
++        focuswin(arg);
++        return;
++    }
++
+ 	if (!selmon->sel)
+ 		return;
+ 	if (arg->i > 0) {
+-		for (c = selmon->sel->next; c && !ISVISIBLE(c); c = c->next);
++		for (c = selmon->sel->next; c && (!ISVISIBLE(c) || HIDDEN(c)); c = c->next);
+ 		if (!c)
+-			for (c = selmon->clients; c && !ISVISIBLE(c); c = c->next);
++			for (c = selmon->clients; c && (!ISVISIBLE(c) || HIDDEN(c)); c = c->next);
+ 	} else {
+ 		for (i = selmon->clients; i != selmon->sel; i = i->next)
+-			if (ISVISIBLE(i))
++			if (ISVISIBLE(i) && !HIDDEN(i))
+ 				c = i;
+ 		if (!c)
+ 			for (; i; i = i->next)
+-				if (ISVISIBLE(i))
++				if (ISVISIBLE(i) && !HIDDEN(i))
+ 					c = i;
+ 	}
+ 	if (c) {
+@@ -1734,6 +1744,118 @@ toggletag(const Arg *arg)
  	}
  }
  
 +void hidewin(const Arg *arg) {
-+	if (!selmon->sel)
-+		return;
-+	Client *c = (Client*)selmon->sel;
-+	hide(c);
-+	hiddenWinStack[++hiddenWinStackTop] = c;
++    if (!selmon->sel)
++        return;
++    Client *c = (Client *)selmon->sel;
++    hide(c);
++    hiddenWinStack[++hiddenWinStackTop] = c;
 +}
 +
 +void restorewin(const Arg *arg) {
-+	int i = hiddenWinStackTop;
-+	while (i > -1) {
-+		if (HIDDEN(hiddenWinStack[i]) && hiddenWinStack[i]->tags == selmon->tagset[selmon->seltags]) {
-+			show(hiddenWinStack[i]);
-+			focus(hiddenWinStack[i]);
-+			restack(selmon);
-+			for (int j = i; j < hiddenWinStackTop; ++j) {
-+				hiddenWinStack[j] = hiddenWinStack[j + 1];
-+			}
-+			--hiddenWinStackTop;
-+			return;
-+		}
-+		--i;
-+	}
++    int i = hiddenWinStackTop;
++    while (i > -1) {
++        if (HIDDEN(hiddenWinStack[i]) &&
++            hiddenWinStack[i]->tags == selmon->tagset[selmon->seltags]) {
++            show(hiddenWinStack[i]);
++            focus(hiddenWinStack[i]);
++            restack(selmon);
++            for (int j = i; j < hiddenWinStackTop; ++j) {
++                hiddenWinStack[j] = hiddenWinStack[j + 1];
++            }
++            --hiddenWinStackTop;
++            return;
++        }
++        --i;
++    }
 +}
 +
-
 +void hideotherwins(const Arg *arg) {
 +    Client *c = NULL, *i;
 +    if (!selmon->sel)
@@ -91,7 +117,6 @@ index 770a4bc..8dc728e 100644
 +        if (HIDDEN(hiddenWinStack[i]) &&
 +            hiddenWinStack[i]->tags == selmon->tagset[selmon->seltags]) {
 +            show(hiddenWinStack[i]);
-+            focus(hiddenWinStack[i]);
 +            restack(selmon);
 +            memcpy(hiddenWinStack + i, hiddenWinStack + i + 1,
 +                   (hiddenWinStackTop - i) * sizeof(Client *));
@@ -99,6 +124,21 @@ index 770a4bc..8dc728e 100644
 +            --i;
 +        }
 +    }
++}
++
++int issinglewin(const Arg *arg) {
++    Client *c = NULL;
++    int cot = 0;
++    int tag = selmon->tagset[selmon->seltags];
++    for (c = selmon->clients; c; c = c->next) {
++        if (ISVISIBLE(c) && !HIDDEN(c) && c->tags == tag) {
++            cot++;
++        }
++        if (cot > 1) {
++            return 0;
++        }
++    }
++    return 1;
 +}
 +
 +void focuswin(const Arg *arg) {
@@ -144,7 +184,6 @@ index 770a4bc..8dc728e 100644
 +    }
 +}
 +
-
  void
- togglewin(const Arg *arg)
+ toggleview(const Arg *arg)
  {


### PR DESCRIPTION
Hello up. Thanks for your prompt relpy and test on my PR. If not using `hideotherwins`, directly using `focuswin` exactly will lead to the dwm crash which is writen in README. However, there is a **simple alternative method to fix it**. We don't need to the shortcut of `focuswin`. Directly **using the shortcut of `focusstack`** may be a better choice. If there is **just one visible window** in one tag, change `focusstack` to `focuswin`. emm...seems to be ok.  

Therefore, I overwrite the function `focusstack` to make it. Meanwhile, I find **a bug in your original patch.** If we use `hidewin` to hidden a window, then we cannot use `focusstack` to traverse all visible windows in a tag. Beacuse the judgement in `focusstack` is `ISVISIBLE`, not including `HIDEEN`. And **`HIDEEN` window is `VISIBLE`**, therefore we cannot pass the hidden window. Just add a `HIDEEN judgement`.
I mention that this patch is based on `awesomebar patch`, if someone don't patch  `awesomebar`, this patch will not work well.(HIDEEN, hide, show and so on are all from awesomebar patch)

Finally, thanks a lot, David Chen. I learn a lot form your bilibili channel although I am just a CS freshman who just learn how to program for one year. 